### PR TITLE
【Fixed】rails gの時にassetsファイル、helperが生成されないように改善

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -10,6 +10,10 @@ module FacebookClone
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.1
+    config.generators do |g|
+      g.assets     false
+      g.helper     false
+    end
 
     # Configuration for the application, engines, and railties goes here.
     #


### PR DESCRIPTION
＃1